### PR TITLE
check for data in demand field

### DIFF
--- a/custom_components/rainforest/sensor.py
+++ b/custom_components/rainforest/sensor.py
@@ -143,7 +143,7 @@ class EMU2Sensor(Entity):
                     except:
                         continue
                                 
-                    if xmlTree.tag == 'InstantaneousDemand':
+                    if xmlTree.tag == 'InstantaneousDemand' and xmlTree.find('Demand').text != None:
                         demand = int(xmlTree.find('Demand').text, 16)
                         demand = -(demand & 0x80000000) | (demand & 0x7fffffff)
                         multiplier = int(xmlTree.find('Multiplier').text, 16)


### PR DESCRIPTION
Device occasionally loses connection to power meter and shows "_ _ _ kW" which shows up in the xml as None.  This edit will check for that condition instead of dying and throwing an uncaught exception