### PR TITLE
Fix attribute generation for HA >= 2022.04.

### DIFF
--- a/custom_components/rainforest/manifest.json
+++ b/custom_components/rainforest/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.2.3",
+  "version": "0.2.4",
   "domain": "rainforest",
   "name": "Rainforest",
   "documentation": "https://github.com/damienheiser/home-assistant/blob/master/custom_components/rainforest/readme.md",

--- a/custom_components/rainforest/sensor.py
+++ b/custom_components/rainforest/sensor.py
@@ -83,7 +83,7 @@ class EMU2Sensor(Entity):
         return self._name
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         return {
             ATTR_DEVICE_MAC_ID: self._data.get(ATTR_DEVICE_MAC_ID),
             ATTR_METER_MAC_ID: self._data.get(ATTR_METER_MAC_ID),


### PR DESCRIPTION
The `device_state_attributes` property was deprecated and replaced with `extra_state_attributes`. To bring those attributes back, update the property name to match.

Fixes #9.